### PR TITLE
Add docker/install.sh for Dockerfile to install jvmkill easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ Run Java with the agent added as a JVM argument:
 
 Alternatively, if modifying the Java command line is not possible, the
 above may be added to the `JAVA_TOOL_OPTIONS` environment variable.
+
+# Docker
+
+Add following lines to Dockerfile to install jvmkill to /usr/local/lib/jvmkill.so:
+
+    ADD https://github.com/frsyuki/jvmkill/raw/master/docker/install_jvmkill.sh install_jvmkill.sh
+    RUN bash install_jvmkill.sh
+
+Note that jvmkill doesn't work if java process runs as PID 1 (because Linux
+kernel doesn't let user processes send KILL signal to PID 1). This is a problem
+with Docker because Docker runs a process as PID 1 by default. You can add
+`--init` option to `docker run` command so that an init process always runs as
+PID 1 and java process runs as a child process.
+

--- a/docker/install_jvmkill.sh
+++ b/docker/install_jvmkill.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -ex
+
+JVMKILL_VERSION=${JVMKILL_VERSION:-8214df6de53d0f8aaf47d032cb1aa047671af0ce}
+export JAVA_HOME="${JAVA_HOME:-$(readlink -f $(which javac) | sed s:/bin/javac::)}"
+
+# Ubuntu
+apt-get update
+
+apt-get install -y wget unzip gcc make
+apt-mark auto wget unzip gcc make
+
+wget -O jvmkill-${JVMKILL_VERSION}.zip "https://github.com/airlift/jvmkill/archive/${JVMKILL_VERSION}.zip"
+unzip jvmkill-${JVMKILL_VERSION}.zip
+cd jvmkill-${JVMKILL_VERSION}
+make
+make test  2>&1 | grep -q "killing current process"
+install -m 755 libjvmkill.so /usr/local/lib
+cd ..
+
+rm -rf jvmkill-${JVMKILL_VERSION} jvmkill-${JVMKILL_VERSION}.zip
+apt-get autoremove --purge -y
+rm -rf /var/lib/apt/lists/*
+
+rm -f install_jvmkill.sh
+


### PR DESCRIPTION
This script makes it easy to install jvmkill in a Dockerfile.
Add following lines to Dockerfile:

    ADD https://github.com/frsyuki/jvmkill/raw/master/docker/install_jvmkill.sh install_jvmkill.sh
    RUN bash install_jvmkill.sh